### PR TITLE
Fixed output to file for on-prem parts of o365 deployments

### DIFF
--- a/UhOh365.py
+++ b/UhOh365.py
@@ -54,6 +54,8 @@ def thread_worker(args):
             elif r.status_code == 302:
                 if domain_is_o365[domain] and not 'outlook.office365.com' in r.text:
                     print("VALID: ", email)
+                    if args.output is not None:
+                        print_queue.put(email)
             else:
                 if args.verbose:
                     print("INVALID: ", email)


### PR DESCRIPTION
Email addresses for on-prem deployments are only being printed to the screen and not being written to the output file. 