### PR TITLE
Added check for "X-MailboxGuid" in HTTP 200 response headers.

### DIFF
--- a/UhOh365.py
+++ b/UhOh365.py
@@ -57,7 +57,7 @@ def thread_worker(args):
                                 print("It doesn't look like '{}' uses o365".format(domain))
                             domain_is_o365[domain] = False
             r = requests.get('https://outlook.office365.com/autodiscover/autodiscover.json/v1.0/{}?Protocol=Autodiscoverv1'.format(email), headers=headers, verify=args.nossl, allow_redirects=False, proxies=proxies)
-            if r.status_code == 200:
+            if r.status_code == 200 and "X-MailboxGuid" in r.headers.keys():
                 print("VALID: ", email)
                 if args.output is not None:
                     print_queue.put(email)


### PR DESCRIPTION
Autodiscover responds with HTTP 200 if logic words, such as "and",
"not", etc are included in an email address. However, these false
positives lack an "X-MailboxGuid" in their responses.

E.g., "fake.email.address@domain.com" -> HTTP 302
"and.fake.email.address@domain.com" -> HTTP 200

(Apologies for the double PR. Broke my original fork.)